### PR TITLE
feat: add more endpoints, fix existing, adjust client headers, some jsdoc

### DIFF
--- a/src/BitClout.ts
+++ b/src/BitClout.ts
@@ -126,6 +126,8 @@ export class BitClout {
       baseURL: this.baseUrl,
       headers: {
         "Content-Type": "application/json",
+        Accept: "application/json",
+        "Accept-Encoding": "gzip",
       },
     });
     return client;

--- a/src/BitClout.ts
+++ b/src/BitClout.ts
@@ -11,12 +11,38 @@ export class BitClout {
     this.baseUrl = baseUrl;
   }
 
+  /**
+   * Get BitClout exchange rate, total amount of nanos sold, and Bitcoin exchange rate.
+   */
+  async getExchangeRate() {
+    const path = "/v0/get-exchange-rate";
+
+    const result = await this.getClient().get(path);
+
+    return result?.data;
+  }
+
+  /**
+   * Get state of BitClout App, such as cost of profile creation and diamond level map.
+   */
+  async getAppState() {
+    const path = "/v0/get-app-state";
+
+    const result = await this.getClient().post(path, {});
+
+    return result?.data;
+  }
+
+  /**
+   * Get hodling information about a specific Public Key (isHodlingPublicKey) given
+   * a hodler Public Key (publicKey)
+   */
   async getIsHodlingPublicKey({
     publicKey,
     isHodlingPublicKey,
   }: {
-    publicKey?: string;
-    isHodlingPublicKey?: string;
+    publicKey: string;
+    isHodlingPublicKey: string;
   }) {
     if (!publicKey) {
       throw new Error("publicKey is required");
@@ -37,6 +63,9 @@ export class BitClout {
     return result?.data;
   }
 
+  /**
+   * Get information about single profile.
+   */
   async getSingleProfile({
     publicKey,
     username,
@@ -59,6 +88,9 @@ export class BitClout {
     return result?.data;
   }
 
+  /**
+   * Get information about users. Request contains a list of public keys of users to fetch.
+   */
   async getUsersStateless({ publicKeys }: { publicKeys: string[] }) {
     const path = "/v0/get-users-stateless";
     const data = {
@@ -70,6 +102,9 @@ export class BitClout {
     return result?.data;
   }
 
+  /**
+   * Get followers for given Public Key.
+   */
   async getFollowsStateless({
     publicKey,
     getEntriesFollowingUsername,
@@ -90,27 +125,110 @@ export class BitClout {
     return result?.data;
   }
 
+  /**
+   * Get BalanceEntryResponses for hodlings
+   */
   async getHoldersForPublicKey({
-    readerPublicKey,
     publicKey,
+    username,
     numToFetch,
+    fetchHodlings,
+    lastPublicKey,
+    fetchAll,
   }: {
-    readerPublicKey: string;
     publicKey: string;
+    username?: string;
     numToFetch: number;
+    fetchHodlings?: boolean;
+    lastPublicKey?: string;
+    fetchAll?: boolean;
   }) {
+    if (!publicKey && !username) {
+      throw new Error("publicKey or username are required");
+    }
+
+    if (!numToFetch) {
+      throw new Error("numToFetch is required");
+    }
+
     const path = "/v0/get-hodlers-for-public-key";
     const data = {
-      ReaderPublicKeyBase58Check: readerPublicKey,
+      Username: username,
+      FetchAll: fetchAll,
       PublicKeyBase58Check: publicKey,
       NumToFetch: numToFetch,
+      LastPublicKeyBase58Check: lastPublicKey,
+      FetchHodlings: fetchHodlings,
     };
 
     const result = await this.getClient().post(path, data);
     return result?.data;
   }
 
+  /**
+   * Get notifications for a given public key.
+   * All parameters are required to get a response.
+   * fetchStartIndex can be set to -1.
+   */
+  async getNotifications({
+    publicKey,
+    fetchStartIndex,
+    numToFetch,
+  }: {
+    publicKey: string;
+    fetchStartIndex: number;
+    numToFetch: number;
+  }) {
+    if (!publicKey) {
+      throw new Error("publicKey is required");
+    }
+
+    if (!fetchStartIndex) {
+      throw new Error("fetchStartIndex is required");
+    }
+
+    if (!numToFetch) {
+      throw new Error("numToFetch is required");
+    }
+
+    const path = "/v0/get-notifications";
+    const data = {
+      PublicKeyBase58Check: publicKey,
+      FetchStartIndex: fetchStartIndex,
+      NumToFetch: numToFetch,
+    };
+
+    const result = await this.getClient().post(path, data);
+
+    return result?.data;
+  }
+
+  /**
+   * Check if Txn is currently in mempool.
+   */
+  async getTransaction({ txnHashHex }: { txnHashHex: string }) {
+    if (!txnHashHex) {
+      throw new Error("txnHashHex is required");
+    }
+
+    const path = "/v0/get-txn";
+    const data = {
+      TxnHashHex: txnHashHex,
+    };
+
+    const result = await this.getClient().post(path, data);
+
+    return result?.data;
+  }
+
+  /**
+   * Submit transaction to BitClout blockchain.
+   */
   async submitTransaction({ transactionHex }: { transactionHex: string }) {
+    if (!transactionHex) {
+      throw new Error("transactionHex is required");
+    }
+
     const path = "/v0/submit-transaction";
     const data = {
       TransactionHex: transactionHex,

--- a/src/BitClout.ts
+++ b/src/BitClout.ts
@@ -15,8 +15,8 @@ export class BitClout {
     publicKey,
     isHodlingPublicKey,
   }: {
-    publicKey?: string;
-    isHodlingPublicKey?: string;
+    publicKey: string;
+    isHodlingPublicKey: string;
   }) {
     if (!publicKey) {
       throw new Error("publicKey is required");

--- a/src/BitClout.ts
+++ b/src/BitClout.ts
@@ -11,6 +11,32 @@ export class BitClout {
     this.baseUrl = baseUrl;
   }
 
+  async getIsHodlingPublicKey({
+    publicKey,
+    isHodlingPublicKey,
+  }: {
+    publicKey?: string;
+    isHodlingPublicKey?: string;
+  }) {
+    if (!publicKey) {
+      throw new Error("publicKey is required");
+    }
+
+    if (!isHodlingPublicKey) {
+      throw new Error("isHodlingPublicKey is required");
+    }
+
+    const path = "/v0/is-hodling-public-key";
+    const data = {
+      PublicKeyBase58Check: publicKey,
+      IsHodlingPublicKeyBase58Check: isHodlingPublicKey,
+    };
+
+    const result = await this.getClient().post(path, data);
+
+    return result?.data;
+  }
+
   async getSingleProfile({
     publicKey,
     username,


### PR DESCRIPTION
Adding a not very visible / documented BitClout endpoint `/v0/is-hodling-public-key` that is useful when knowing if a public key holds another CC and said balance held (and if purchased or received).

Also took the opportunity to add `gzip` headers to the client. The BitClout API does recognise them and uses them.

Let me know if you want contributors to run anything prior to PRs. I only ran `format`.